### PR TITLE
Clean up default / example User-Agent strings

### DIFF
--- a/cmd/scaffold/snowman.yaml
+++ b/cmd/scaffold/snowman.yaml
@@ -1,4 +1,4 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman project boilerplate. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "project-boilerplate Snowman (https://github.com/glaciers-in-archives/snowman)"

--- a/examples/configuration/snowman.yaml
+++ b/examples/configuration/snowman.yaml
@@ -1,6 +1,6 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers:
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"
 metadata:
   a_config_key: "a config value"

--- a/examples/inline-queries/snowman.yaml
+++ b/examples/inline-queries/snowman.yaml
@@ -1,4 +1,4 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"

--- a/examples/multilingual/snowman.yaml
+++ b/examples/multilingual/snowman.yaml
@@ -1,4 +1,4 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"

--- a/examples/non-html-content/snowman.yaml
+++ b/examples/non-html-content/snowman.yaml
@@ -1,4 +1,4 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"

--- a/examples/static-advanced/snowman.yaml
+++ b/examples/static-advanced/snowman.yaml
@@ -1,7 +1,7 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"
 metadata:
   # whatever data you might need as long as it's valid YAML
   about: "Custom data for your site."

--- a/examples/wikidata/snowman.yaml
+++ b/examples/wikidata/snowman.yaml
@@ -1,4 +1,4 @@
 sparql_client:
   endpoint: "https://query.wikidata.org/sparql"
   http_headers: 
-    User-Agent: "Snowman build example. https://github.com/glaciers-in-archives/snowman"
+    User-Agent: "example Snowman (https://github.com/glaciers-in-archives/snowman)"


### PR DESCRIPTION
Each space-separated, non-parenthesized part of the User-Agent field is supposed to identify a different product (i.e. product names shouldn’t include spaces), and URLs are conventionally put in a comment (i.e. wrapped in parentheses). See the example in the [User-Agent policy][1], and [section 5.5.3 of RFC 7231][2].

The User-Agent field can also contain a version number for a product (after a slash), but it seems header values don’t resolve commands, so something like `Snowman/{{ version }}` doesn’t work.

[1]: https://meta.wikimedia.org/wiki/User-Agent_policy
[2]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3