### PR TITLE
🔧 drop text version of template functions

### DIFF
--- a/internal/template/function/include.go
+++ b/internal/template/function/include.go
@@ -15,7 +15,7 @@ func include(templatePath string, arguments ...interface{}) (html_template.HTML,
 		return "", errors.New("Unable to find the template file " + templatePath)
 	}
 
-	tpl, err := html_template.New("").Funcs((GetHTMLIncludeFuncs())).Funcs(GetHTMLQueryFuncs()).Funcs(GetHTMLStringFuncs()).Funcs(GetHTMLMathFuncs()).Funcs(GetHTMLUtilsFuncs()).ParseFiles(templatePath)
+	tpl, err := html_template.New("").Funcs((GetIncludeFuncs())).Funcs(GetQueryFuncs()).Funcs(GetStringFuncs()).Funcs(GetMathFuncs()).Funcs(GetUtilsFuncs()).ParseFiles(templatePath)
 	if err != nil {
 		return "", err
 	}
@@ -41,7 +41,7 @@ func include_text(templatePath string, arguments ...interface{}) (string, error)
 		return "", errors.New("Unable to find the template file " + templatePath)
 	}
 
-	tpl, err := text_template.New("").Funcs((GetTextIncludeFuncs())).Funcs(GetTextQueryFuncs()).Funcs(GetTextStringFuncs()).Funcs(GetTextMathFuncs()).Funcs(GetTextUtilsFuncs()).ParseFiles(templatePath)
+	tpl, err := text_template.New("").Funcs((GetIncludeFuncs())).Funcs(GetQueryFuncs()).Funcs(GetStringFuncs()).Funcs(GetMathFuncs()).Funcs(GetUtilsFuncs()).ParseFiles(templatePath)
 	if err != nil {
 		return "", err
 	}
@@ -68,10 +68,6 @@ func init() {
 	includeFuncs["include_text"] = include_text
 }
 
-func GetHTMLIncludeFuncs() html_template.FuncMap {
+func GetIncludeFuncs() html_template.FuncMap {
 	return html_template.FuncMap(includeFuncs)
-}
-
-func GetTextIncludeFuncs() text_template.FuncMap {
-	return text_template.FuncMap(includeFuncs)
 }

--- a/internal/template/function/json.go
+++ b/internal/template/function/json.go
@@ -3,8 +3,6 @@ package function
 import (
 	"encoding/json"
 	"html/template"
-	html_template "html/template"
-	text_template "text/template"
 )
 
 var jsonFuncs = map[string]interface{}{
@@ -21,10 +19,6 @@ func toJSON(arg interface{}) (template.HTML, error) {
 	return template.HTML(b), nil
 }
 
-func GetHTMLJSONFuncs() html_template.FuncMap {
-	return html_template.FuncMap(jsonFuncs)
-}
-
-func GetTextJSONFuncs() text_template.FuncMap {
-	return text_template.FuncMap(jsonFuncs)
+func GetJSONFuncs() template.FuncMap {
+	return template.FuncMap(jsonFuncs)
 }

--- a/internal/template/function/math.go
+++ b/internal/template/function/math.go
@@ -1,9 +1,8 @@
 package function
 
 import (
-	html_template "html/template"
+	"html/template"
 	"math/rand"
-	text_template "text/template"
 
 	"github.com/spf13/cast"
 )
@@ -30,10 +29,6 @@ var mathFuncs = map[string]interface{}{
 	"rand": func(min, max int) int { return rand.Intn(max-min) + min },
 }
 
-func GetHTMLMathFuncs() html_template.FuncMap {
-	return html_template.FuncMap(mathFuncs)
-}
-
-func GetTextMathFuncs() text_template.FuncMap {
-	return text_template.FuncMap(mathFuncs)
+func GetMathFuncs() template.FuncMap {
+	return template.FuncMap(mathFuncs)
 }

--- a/internal/template/function/query.go
+++ b/internal/template/function/query.go
@@ -3,9 +3,8 @@ package function
 import (
 	"errors"
 	"fmt"
-	html_template "html/template"
+	"html/template"
 	"strings"
-	text_template "text/template"
 
 	"github.com/glaciers-in-archives/snowman/internal/sparql"
 	"github.com/knakk/rdf"
@@ -33,10 +32,6 @@ var queryFuncs = map[string]interface{}{
 	},
 }
 
-func GetHTMLQueryFuncs() html_template.FuncMap {
-	return html_template.FuncMap(queryFuncs)
-}
-
-func GetTextQueryFuncs() text_template.FuncMap {
-	return text_template.FuncMap(queryFuncs)
+func GetQueryFuncs() template.FuncMap {
+	return template.FuncMap(queryFuncs)
 }

--- a/internal/template/function/strings.go
+++ b/internal/template/function/strings.go
@@ -1,9 +1,8 @@
 package function
 
 import (
-	html_template "html/template"
+	"html/template"
 	"strings"
-	text_template "text/template"
 
 	"github.com/spf13/cast"
 )
@@ -56,10 +55,6 @@ func trim(str interface{}) string {
 	return strings.TrimSpace(cast.ToString(str))
 }
 
-func GetHTMLStringFuncs() html_template.FuncMap {
-	return html_template.FuncMap(stringFuncs)
-}
-
-func GetTextStringFuncs() text_template.FuncMap {
-	return text_template.FuncMap(stringFuncs)
+func GetStringFuncs() template.FuncMap {
+	return template.FuncMap(stringFuncs)
 }

--- a/internal/template/function/utils.go
+++ b/internal/template/function/utils.go
@@ -2,9 +2,8 @@ package function
 
 import (
 	"fmt"
-	html_template "html/template"
+	"html/template"
 	"os"
-	text_template "text/template"
 	"time"
 
 	"github.com/glaciers-in-archives/snowman/internal/config"
@@ -16,8 +15,8 @@ import (
 var utilFuncs = map[string]interface{}{
 	"now": time.Now,
 	"env": os.Getenv,
-	"safe_html": func(str interface{}) html_template.HTML {
-		return html_template.HTML(cast.ToString(str))
+	"safe_html": func(str interface{}) template.HTML {
+		return template.HTML(cast.ToString(str))
 	},
 	"uri": func(value string) (rdf.IRI, error) {
 		return rdf.NewIRI(value)
@@ -33,10 +32,6 @@ var utilFuncs = map[string]interface{}{
 	},
 }
 
-func GetHTMLUtilsFuncs() html_template.FuncMap {
-	return html_template.FuncMap(utilFuncs)
-}
-
-func GetTextUtilsFuncs() text_template.FuncMap {
-	return text_template.FuncMap(utilFuncs)
+func GetUtilsFuncs() template.FuncMap {
+	return template.FuncMap(utilFuncs)
 }

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -97,9 +97,9 @@ func DiscoverViews(layouts []string) ([]View, error) {
 		var TextTemplateA *text_template.Template
 		var HTMLTemplateA *html_template.Template
 		if viewConf.Unsafe {
-			TextTemplateA, err = text_template.New("").Funcs(function.GetTextQueryFuncs()).Funcs(function.GetTextStringFuncs()).Funcs(function.GetTextMathFuncs()).Funcs(function.GetTextUtilsFuncs()).Funcs(function.GetTextIncludeFuncs()).Funcs(function.GetTextJSONFuncs()).ParseFiles(templates...)
+			TextTemplateA, err = text_template.New("").Funcs(function.GetQueryFuncs()).Funcs(function.GetStringFuncs()).Funcs(function.GetMathFuncs()).Funcs(function.GetUtilsFuncs()).Funcs(function.GetIncludeFuncs()).Funcs(function.GetJSONFuncs()).ParseFiles(templates...)
 		} else {
-			HTMLTemplateA, err = html_template.New("").Funcs(function.GetHTMLQueryFuncs()).Funcs(function.GetHTMLStringFuncs()).Funcs(function.GetHTMLMathFuncs()).Funcs(function.GetHTMLUtilsFuncs()).Funcs(function.GetHTMLIncludeFuncs()).Funcs(function.GetHTMLJSONFuncs()).ParseFiles(templates...)
+			HTMLTemplateA, err = html_template.New("").Funcs(function.GetQueryFuncs()).Funcs(function.GetStringFuncs()).Funcs(function.GetMathFuncs()).Funcs(function.GetUtilsFuncs()).Funcs(function.GetIncludeFuncs()).Funcs(function.GetJSONFuncs()).ParseFiles(templates...)
 		}
 
 		if err != nil {


### PR DESCRIPTION
From Go 1.19 text and HTML template functions can be use with either text or HTML templates so we do no longer need to duplicate them.

TODOs

 - Unify `include` functions
 - Refactor template function initiation so that we can pull all functions from one place