### PR TITLE
Replace / with os.PathSeparator

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/glaciers-in-archives/snowman/internal/config"
@@ -23,7 +23,7 @@ var configFileLocation string
 
 func DiscoverLayouts() ([]string, error) {
 	var paths []string
-	filepath.Walk("templates/layouts", func(path string, info os.FileInfo, err error) error {
+	fs.WalkDir(os.DirFS("."), "templates/layouts", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ func DiscoverQueries() (map[string]string, error) {
 		return index, nil
 	}
 
-	err := filepath.Walk("queries", func(path string, info os.FileInfo, err error) error {
+	err := fs.WalkDir(os.DirFS("."), "queries", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -53,7 +53,7 @@ func DiscoverQueries() (map[string]string, error) {
 				return err
 			}
 
-			index[strings.Replace(path, "queries"+string(os.PathSeparator), "", 1)] = string(sparqlBytes)
+			index[strings.Replace(path, "queries/", "", 1)] = string(sparqlBytes)
 
 		}
 		return nil

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -53,7 +53,7 @@ func DiscoverQueries() (map[string]string, error) {
 				return err
 			}
 
-			index[strings.Replace(path, "queries/", "", 1)] = string(sparqlBytes)
+			index[strings.Replace(path, "queries"+string(os.PathSeparator), "", 1)] = string(sparqlBytes)
 
 		}
 		return nil

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/glaciers-in-archives/snowman/internal/cache"
@@ -62,12 +62,12 @@ var cacheCmd = &cobra.Command{
 				return utils.ErrorExit("Failed to read last unused cache items: ", err)
 			}
 
-			err = filepath.Walk(cache.CacheLocation, func(path string, info os.FileInfo, err error) error {
+			err = fs.WalkDir(os.DirFS("."), cache.CacheLocation, func(path string, info fs.DirEntry, err error) error {
 				if err != nil {
 					return err
 				}
 
-				pathAsCacheItem := strings.Replace(strings.Replace(path, ".json", "", 1), ".snowman/cache/", "", 1)
+				pathAsCacheItem := strings.Replace(strings.Replace(path, ".json", "", 1), cache.CacheLocation, "", 1)
 				isUsed := false
 				for _, used := range usedItems {
 					if pathAsCacheItem == used || strings.HasPrefix(used, pathAsCacheItem) {

--- a/internal/static/static.go
+++ b/internal/static/static.go
@@ -2,6 +2,7 @@ package static
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,8 +28,9 @@ func ClearStatic() error {
 func CopyIn() error {
 	var writtenFiles []string
 	// This does not include checking if the "from" directory exists
-	err := filepath.Walk("static", func(path string, info os.FileInfo, err error) error {
-		if info.Mode().IsRegular() {
+	err := fs.WalkDir(os.DirFS("."), "static", func(path string, d fs.DirEntry, err error) error {
+		info, _ := d.Info()
+		if info.Mode().IsRegular() { // checks that its not ModeDir | ModeSymlink | ModeNamedPipe | ModeSocket | ModeDevice | ModeCharDevice | ModeIrregular
 			newPath := strings.Replace(path, "static/", "site/", 1)
 			if err := os.MkdirAll(filepath.Dir(newPath), 0770); err != nil {
 				return err


### PR DESCRIPTION
This code changes `/` in a string to `os.PathSeparator` so that queries may be found also on Windows.

Fixes #100. 

I've tested this change locally, first using the prebuilt Snowman:

```powershell
PS C:\snowman-test> .\bin\snowman.exe new
Your project has been created in: my-new-project
You can now run:
cd my-new-project
snowman build
snowman server
PS C:\snowman-test> cd .\my-new-project\
PS C:\snowman-test\my-new-project> ..\bin\snowman.exe build
Building project with 2 views.
Error: SPARQL query failed. Error: The given query could not be found. index.rq
```

Replacing that binary with the one built from this PR:

```powershell
PS C:\snowman-test\my-new-project> ..\bin\snowman.exe build
Building project with 2 views.
Finished building project.
```