### PR TITLE
feat: add construct query support

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -140,7 +140,7 @@ var buildCmd = &cobra.Command{
 			results := make([]map[string]rdf.Term, 0)
 			if view.ViewConfig.QueryFile != "" {
 				printVerbose("Issuing query " + view.ViewConfig.QueryFile)
-				results, err = sparql.CurrentRepository.Query(view.ViewConfig.QueryFile)
+				results, err = sparql.CurrentRepository.QuerySelect(view.ViewConfig.QueryFile)
 				if err != nil {
 					return utils.ErrorExit("SPARQL query failed.", err)
 				}

--- a/internal/sparql/sparql.go
+++ b/internal/sparql/sparql.go
@@ -132,7 +132,7 @@ func (r *Repository) queryCallCached(queryLocation, query, accept string) (io.Re
 	return resultReader, nil
 }
 
-func (r *Repository) Query(queryLocation string, arguments ...interface{}) ([]map[string]rdf.Term, error) {
+func (r *Repository) QuerySelect(queryLocation string, arguments ...interface{}) ([]map[string]rdf.Term, error) {
 	accept := "application/sparql-results+json"
 
 	queryBody, err := r.queryBody(queryLocation, arguments...)
@@ -146,6 +146,29 @@ func (r *Repository) Query(queryLocation string, arguments ...interface{}) ([]ma
 	}
 
 	parsedResponse := ParseSPARQLJSON(responseContents)
+	return parsedResponse, nil
+}
+
+func (r *Repository) QueryConstruct(queryLocation string, arguments ...interface{}) (interface{}, error) {
+	accept := "application/ld+json"
+
+	queryBody, err := r.queryBody(queryLocation, arguments...)
+	if err != nil {
+		return nil, err
+	}
+
+	responseContents, err := r.queryCallCached(queryLocation, *queryBody, accept)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsedResponse interface{}
+
+	err = json.NewDecoder(responseContents).Decode(&parsedResponse)
+	if err != nil {
+		return nil, err
+	}
+
 	return parsedResponse, nil
 }
 

--- a/internal/template/function/query.go
+++ b/internal/template/function/query.go
@@ -7,8 +7,16 @@ import (
 
 func Query(queryLocation string, arguments ...interface{}) ([]map[string]rdf.Term, error) {
 	if len(arguments) == 0 {
-		return sparql.CurrentRepository.Query(queryLocation)
+		return sparql.CurrentRepository.QuerySelect(queryLocation)
 	}
 
-	return sparql.CurrentRepository.Query(queryLocation, arguments...)
+	return sparql.CurrentRepository.QuerySelect(queryLocation, arguments...)
+}
+
+func QueryConstruct(queryLocation string, arguments ...interface{}) (interface{}, error) {
+	if len(arguments) == 0 {
+		return sparql.CurrentRepository.QueryConstruct(queryLocation)
+	}
+
+	return sparql.CurrentRepository.QueryConstruct(queryLocation, arguments...)
 }

--- a/internal/template/function_loader/function_loader.go
+++ b/internal/template/function_loader/function_loader.go
@@ -28,7 +28,8 @@ func FunctionLoader() template.FuncMap {
 		"mul":  function.Mul,
 		"rand": function.Rand,
 
-		"query": function.Query,
+		"query":           function.Query,
+		"query_construct": function.QueryConstruct,
 
 		"get_remote":             function.GetRemote,
 		"get_remote_with_config": function.GetRemoteWithConfig,


### PR DESCRIPTION
I tried to build a SKOS Snowman example, inspired by #114, but there I struggled with the fact that any `skos:Concept` can have any number of `skos:altLabel`, `skos:member`, `skos:related`. 

I guess you could solve with multiple tables/parametrized queries, or even with `GROUP BY`/`GROUP_CONCAT`, but I thought, why not issue SPARQL CONSTRUCT queries that return a dict for each `skos:Concept` and render those. Especially if the endpoint supports a JSON-LD frame to make usable JSON out of the result (haven't written this yet).

Anyways, I've got it to work (a testament to the Snowman code). This templating code also relates to #37. 

```html
{{ $concepts := query_construct "items2.rq" .coll }}
<article class="directory-entry concept">
    <dl>
        <dt>ID:</dt>
        <dd><a href="{{ index . "@id" }}">{{ index . "@id" }}</a></dd>
        <dt>PrefLabels</dt>
        {{ range (index . "http://www.w3.org/2004/02/skos/core#prefLabel") }}
            <dd lang="{{ index . "@lang" }}">{{ index . "@value" }}</dd>
        {{ end }}
        {{ if (index . "http://www.w3.org/2004/02/skos/core#definition") }}
            <dt>Definition</dt>
            {{ range (index . "http://www.w3.org/2004/02/skos/core#definition") }}
                <dd lang="{{ index . "@lang" }}">{{ index . "@value" }}</dd>
            {{ end }}
        {{ end }}
        {{ if (index . "http://www.w3.org/2004/02/skos/core#related") }}
            <dt>Related</dt>
            {{ range (index . "http://www.w3.org/2004/02/skos/core#related") }}
                <dd>{{ index . "@id" }}</dd>
            {{ end }}
        {{ end }}
    </dl>
</article>
```

<img width="778" height="265" alt="The above template code rendered with a Dutch definition on Galvanic Cathode Protection." src="https://github.com/user-attachments/assets/8061ebb7-2d9a-4dc7-abe4-6de45c30d19b" />

That templating code however is rather different than regular SELECT query templates and idk if this is worthy to pursue any further. If you think it'd be useful to have in Snowman, then I can complete this feature by writing some documentation and try and add JSON-LD-Frame support, too.

The above template is from https://github.com/redmer/spheniskos/tree/v1, which (on my laptop) uses a custom build that uses the proposed `query_construct`. Very much work-in-progress.
