### PR TITLE
feat: make the site directory presist accross builds

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -132,8 +132,8 @@ var buildCmd = &cobra.Command{
 			return utils.ErrorExit("Failed to discover views.", err)
 		}
 
-		if err := os.RemoveAll("site"); err != nil {
-			return utils.ErrorExit("Failed to remove the existing site directory.", err)
+		if err := utils.EmptyDir("site"); err != nil {
+			return utils.ErrorExit("Failed to empty the existing site directory.", err)
 		}
 
 		if _, err := os.Stat("static"); os.IsNotExist(err) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -99,6 +99,22 @@ func CountFilesRecursive(dir string) (int, error) {
 	return count, nil
 }
 
+func EmptyDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 var illegalPath = regexp.MustCompile(`[\~\:\*\?\"\<\>\|]`)
 var illegalNextToEachOther = regexp.MustCompile(`[\.\/]{2,}`)
 var illegalStartAndEnd = regexp.MustCompile(`^[\./]|[\./]$`)


### PR DESCRIPTION
This makes it so that (re)building does not delete and recreate the "site" directory. This ensures that premissions presist and that processes that might watch or run in the directory won't fail.

Discussion: https://github.com/glaciers-in-archives/snowman/discussions/127